### PR TITLE
update: build for linux OS(Ubuntu, Arch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ name = "catswords-jsrt-sys"
 version = "0.3.0"
 dependencies = [
  "cc",
+ "cmake",
 ]
 
 [[package]]
@@ -32,6 +33,15 @@ checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/crates/catswords-jsrt-sys/Cargo.toml
+++ b/crates/catswords-jsrt-sys/Cargo.toml
@@ -29,5 +29,6 @@ default = []
 
 [build-dependencies]
 cc = { workspace = true }
+cmake = "0.1.58"
 
 [dependencies]

--- a/crates/catswords-jsrt-sys/build.rs
+++ b/crates/catswords-jsrt-sys/build.rs
@@ -27,12 +27,12 @@ fn main() {
             .define("CMAKE_CXX_COMPILER", "clang++")
             .define("CMAKE_ASM_COMPILER", "clang")
             .env("NUM_JOBS", "30")
-            .build_target("ChakraCore")
+            .build_target("ChakraCoreStatic")
             .build()
             ;
 
         println!("cargo:rustc-link-search=native={}/build/lib", dst.display());
-        println!("cargo:rustc-link-lib=dylib=ChakraCore");
+        println!("cargo:rustc-link-lib=static=ChakraCoreStatic");
         println!("cargo:rustc-link-lib=dylib=stdc++");
         println!("cargo:rustc-link-lib=dylib=icuuc");
         println!("cargo:rustc-link-lib=dylib=icui18n");

--- a/crates/catswords-jsrt-sys/build.rs
+++ b/crates/catswords-jsrt-sys/build.rs
@@ -31,6 +31,7 @@ fn main() {
             .build()
             ;
 
+        println!("cargo:rustc-link-search=native={}/build/", dst.display());
         println!("cargo:rustc-link-search=native={}/build/bin/ChakraCore", dst.display());
         println!("cargo:rustc-link-lib=dylib=ChakraCore");
         println!("cargo:rustc-link-lib=dylib=stdc++");

--- a/crates/catswords-jsrt-sys/build.rs
+++ b/crates/catswords-jsrt-sys/build.rs
@@ -1,35 +1,133 @@
+struct CKRBuilder {
+    out_dir: String,
+}
+
 fn main() {
     let out_dir     : String = std::env::var("OUT_DIR").unwrap();
-    let out_ckr_dir : String = format!("{out_dir}/ckr");
-    let mut c : bool = false;
+    let builder     : CKRBuilder = CKRBuilder {
+        out_dir : format!("{out_dir}/ckr")
+    };
 
     println!("cargo:rerun-if-env-changed=CHAKRACORE_INCLUDE_DIR");
     println!("cargo:rerun-if-env-changed=CHAKRACORE_LIB_DIR");
 
     match std::env::var("CHAKRACORE_INCLUDE_DIR") {
-        Ok( _) => {}
-        Err(_) =>  { c = true; }
+        Ok( _) => {
+            println!("CHAKRACORE_INCLUDE_DIR has set. (not very meaningful though)");
+        }
+        Err(_) =>  { }
     }
 
     match std::env::var("CHAKRACORE_LIB_DIR") {
-        Ok(_) => {}
-        Err(_) =>  { c = true; }
+        Ok(path) => {
+            println!("There is chakracore somewhere {}", path);
+            println!("cargo:rustc-link-search=native={}/", path);
+            println!("cargo:rustc-link-search=native={}/bin", path);
+            println!("cargo:rustc-link-search=native={}/lib", path);
+            println!("cargo:rustc-link-lib=dylib=ChakraCore");
+            return;
+        }
+        Err(_) => {}
     }
 
-    if c {
-        let _ = std::process::Command::new("git")
-            .args(["clone", "https://github.com/chakra-core/ChakraCore", out_ckr_dir.as_str(), "--depth", "1"])
-            .output()
-            .expect("Failed to fetch ChakraCore: https://github.com/chakra-core/ChakraCore");
+    builder.fetch()
+        .expect("Failed to fetch ChakraCore: https://github.com/chakra-core/ChakraCore")
+        .build()
+        .expect("");
+}
 
-        let dst = cmake::Config::new(out_ckr_dir)
+/* TODO: change check_vs, need support cmd and PS. and separate about build.
+*/
+
+fn visual_studio_exists() -> bool {
+    let check_vs = std::process::Command::new("vswhere")
+        .args(["-latest",
+            "-requires", "Microsoft.VisualStudio.Workload.NativeDesktop",
+            "-property", "installationPath",])
+        .output();
+
+    match check_vs {
+        Ok(o) =>{ eprintln!("{}", String::from_utf8_lossy(&o.stdout));
+            !o.stdout.is_empty()}, 
+        Err(_) => false,
+    }
+}
+
+impl CKRBuilder {
+    fn fetch(&self) -> Result<&CKRBuilder, std::io::Error> {
+        let r : Result<std::process::Output, std::io::Error> = std::process::Command::new("git")
+            .args(["clone", "https://github.com/chakra-core/ChakraCore", self.out_dir.as_str(), "--depth", "1"])
+            .output();
+
+        match r {
+            Ok( _) => return Ok(self),
+            Err(e) => return Err(e)
+        }
+    }
+
+
+    #[cfg(target_os = "windows")]
+    fn build(&self) -> Result<&CKRBuilder, std::io::Error> {
+
+        match visual_studio_exists() {
+            false => return self.build_fallback(),
+            true => {
+                #[cfg(target_arch = "x86_64")]
+                let arch : &str = "x64";
+                #[cfg(target_arch = "x86")]
+                let arch : &str = "Win32";
+                #[cfg(target_arch = "aarch64")]
+                let arch : &str = "ARM64";
+
+                let submodule_install = std::process::Command::new("git")
+                    .args(["submodule", "update", "--init", "--recursive"])
+                    .output();
+                match submodule_install {
+                    Ok(o) => {
+                        println!("{}", String::from_utf8_lossy(&o.stdout));
+                        println!("{}", String::from_utf8_lossy(&o.stderr));
+                    }
+                    Err(_)=> {
+                        return self.build_fallback();
+                    }
+                }
+
+                let result = std::process::Command::new("msbuild")
+                    .args(["Build\\Chakra.Core.sln",
+                        "/p:Configuration=Release",
+                        &format!("/p:Platform={}", arch),
+                        "/m",
+                    ])
+                    .current_dir(self.out_dir.as_str())
+                    .output();
+
+                match result {
+                    Ok(o) => {
+                        eprintln!("Build Success");
+                        eprintln!("{}", String::from_utf8_lossy(&o.stderr));
+                        return Ok(self);
+                    }
+                    Err(e) => {
+                        println!("Failed to build ChakraCore: {}", e);
+                        return self.build_fallback();
+                    }
+                }
+            }
+        }
+    }
+
+
+    #[cfg(not(target_os = "windows"))]
+    fn build(&self) -> Result<&CKRBuilder, std::io::Error> {
+        return self.build_fallback();
+    }
+    fn build_fallback(&self) -> Result<&CKRBuilder, std::io::Error> {
+        let dst = cmake::Config::new(self.out_dir.as_str())
             .define("CMAKE_C_COMPILER", "clang")
             .define("CMAKE_CXX_COMPILER", "clang++")
             .define("CMAKE_ASM_COMPILER", "clang")
-            .env("NUM_JOBS", "30")
             .build_target("all")
-            .build()
-            ;
+            .build();
 
         println!("cargo:rustc-link-search=native={}/build/", dst.display());
         println!("cargo:rustc-link-search=native={}/build/bin/ChakraCore", dst.display());
@@ -37,15 +135,7 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=stdc++");
         println!("cargo:rustc-link-lib=dylib=icuuc");
         println!("cargo:rustc-link-lib=dylib=icui18n");
-    }
 
-    /* TODO:
-     * what I've written is a fallback when library is not found.
-     * cmake build is unnecessary when include & lib dir has been defined.
-     * 
-     * since there's no such standard way to link libraries
-     * linking from env would be suitable.
-     *
-     * I suggest to use CHAKRACORE_LIB_PATH.
-     * */
+        return Ok(self);
+    }
 }

--- a/crates/catswords-jsrt-sys/build.rs
+++ b/crates/catswords-jsrt-sys/build.rs
@@ -27,12 +27,12 @@ fn main() {
             .define("CMAKE_CXX_COMPILER", "clang++")
             .define("CMAKE_ASM_COMPILER", "clang")
             .env("NUM_JOBS", "30")
-            .build_target("ChakraCoreStatic")
+            .build_target("all")
             .build()
             ;
 
-        println!("cargo:rustc-link-search=native={}/build/lib", dst.display());
-        println!("cargo:rustc-link-lib=static=ChakraCoreStatic");
+        println!("cargo:rustc-link-search=native={}/build/bin/ChakraCore", dst.display());
+        println!("cargo:rustc-link-lib=dylib=ChakraCore");
         println!("cargo:rustc-link-lib=dylib=stdc++");
         println!("cargo:rustc-link-lib=dylib=icuuc");
         println!("cargo:rustc-link-lib=dylib=icui18n");

--- a/crates/catswords-jsrt-sys/build.rs
+++ b/crates/catswords-jsrt-sys/build.rs
@@ -1,20 +1,50 @@
-use std::env;
-
 fn main() {
-    let inc = env::var("CHAKRACORE_INCLUDE_DIR")
-        .expect("CHAKRACORE_INCLUDE_DIR not set (path to ChakraCore headers directory)");
-    let lib = env::var("CHAKRACORE_LIB_DIR")
-        .expect("CHAKRACORE_LIB_DIR not set (path to ChakraCore import library directory)");
+    let out_dir     : String = std::env::var("OUT_DIR").unwrap();
+    let out_ckr_dir : String = format!("{out_dir}/ckr");
+    let mut c : bool = false;
 
     println!("cargo:rerun-if-env-changed=CHAKRACORE_INCLUDE_DIR");
     println!("cargo:rerun-if-env-changed=CHAKRACORE_LIB_DIR");
 
-    // Expose include dir as build metadata (useful for downstream tooling)
-    println!("cargo:include={}", inc);
+    match std::env::var("CHAKRACORE_INCLUDE_DIR") {
+        Ok( _) => {}
+        Err(_) =>  { c = true; }
+    }
 
-    println!("cargo:rustc-link-search=native={}", lib);
+    match std::env::var("CHAKRACORE_LIB_DIR") {
+        Ok(_) => {}
+        Err(_) =>  { c = true; }
+    }
 
-    // Common Windows import library name: ChakraCore.lib
-    // If your import library name differs, adjust this line.
-    println!("cargo:rustc-link-lib=dylib=ChakraCore");
+    if c {
+        let _ = std::process::Command::new("git")
+            .args(["clone", "https://github.com/chakra-core/ChakraCore", out_ckr_dir.as_str(), "--depth", "1"])
+            .output()
+            .expect("Failed to fetch ChakraCore: https://github.com/chakra-core/ChakraCore");
+
+        let dst = cmake::Config::new(out_ckr_dir)
+            .define("CMAKE_C_COMPILER", "clang")
+            .define("CMAKE_CXX_COMPILER", "clang++")
+            .define("CMAKE_ASM_COMPILER", "clang")
+            .env("NUM_JOBS", "30")
+            .build_target("ChakraCore")
+            .build()
+            ;
+
+        println!("cargo:rustc-link-search=native={}/build/lib", dst.display());
+        println!("cargo:rustc-link-lib=dylib=ChakraCore");
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+        println!("cargo:rustc-link-lib=dylib=icuuc");
+        println!("cargo:rustc-link-lib=dylib=icui18n");
+    }
+
+    /* TODO:
+     * what I've written is a fallback when library is not found.
+     * cmake build is unnecessary when include & lib dir has been defined.
+     * 
+     * since there's no such standard way to link libraries
+     * linking from env would be suitable.
+     *
+     * I suggest to use CHAKRACORE_LIB_PATH.
+     * */
 }

--- a/crates/catswords-jsrt-sys/src/lib.rs
+++ b/crates/catswords-jsrt-sys/src/lib.rs
@@ -87,9 +87,9 @@ extern "C" {
     pub fn JsGetCurrentContext(current_context: *mut JsContextRef) -> JsErrorCode;
 
     pub fn JsRun(
-        script: *const u16,
+        script: JsValueRef,
         source_context: JsSourceContext,
-        source_url: *const u16,
+        source_url: JsValueRef, 
         parseAttributes: JsParseScriptAttributes,
         result: *mut JsValueRef,
     ) -> JsErrorCode;
@@ -145,15 +145,3 @@ extern "C" {
     pub fn JsSetException(exception: JsValueRef) -> JsErrorCode;
 }
 
-pub unsafe fn JsRunScript(
-    script: *const u16,
-    source_context: JsSourceContext,
-    source_url: *const u16,
-    result: *mut JsValueRef,
-) -> JsErrorCode {
-    return JsRun(
-        script
-        , source_context
-        , source_url
-        , JsParseScriptAttributes::None, result);
-}

--- a/crates/catswords-jsrt-sys/src/lib.rs
+++ b/crates/catswords-jsrt-sys/src/lib.rs
@@ -32,6 +32,28 @@ pub enum JsErrorCode {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JsParseScriptAttributes {
+        /// <summary>
+        ///     Default attribute
+        /// </summary>
+        None = 0x0,
+        /// <summary>
+        ///     Specified script is internal and non-user code. Hidden from debugger
+        /// </summary>
+        LibraryCode = 0x1,
+        /// <summary>
+        ///     ChakraCore assumes ExternalArrayBuffer is Utf8 by default.
+        ///     This one needs to be set for Utf16
+        /// </summary>
+        ArrayBufferIsUtf16Encoded = 0x2,
+        /// <summary>
+        ///     Script should be parsed in strict mode
+        /// </summary>
+        StrictMode = 0x4,
+}
+
+#[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub enum JsRuntimeAttributes {
     None = 0,
@@ -64,10 +86,11 @@ extern "C" {
     pub fn JsSetCurrentContext(context: JsContextRef) -> JsErrorCode;
     pub fn JsGetCurrentContext(current_context: *mut JsContextRef) -> JsErrorCode;
 
-    pub fn JsRunScript(
+    pub fn JsRun(
         script: *const u16,
         source_context: JsSourceContext,
         source_url: *const u16,
+        parseAttributes: JsParseScriptAttributes,
         result: *mut JsValueRef,
     ) -> JsErrorCode;
 
@@ -120,4 +143,17 @@ extern "C" {
     pub fn JsGetUndefinedValue(undefined_value: *mut JsValueRef) -> JsErrorCode;
     pub fn JsGetNullValue(null_value: *mut JsValueRef) -> JsErrorCode;
     pub fn JsSetException(exception: JsValueRef) -> JsErrorCode;
+}
+
+pub unsafe fn JsRunScript(
+    script: *const u16,
+    source_context: JsSourceContext,
+    source_url: *const u16,
+    result: *mut JsValueRef,
+) -> JsErrorCode {
+    return JsRun(
+        script
+        , source_context
+        , source_url
+        , JsParseScriptAttributes::None, result);
 }

--- a/crates/catswords-jsrt/src/script.rs
+++ b/crates/catswords-jsrt/src/script.rs
@@ -3,24 +3,33 @@ use crate::guard::Guard;
 use crate::value::Value;
 use catswords_jsrt_sys as sys;
 
-fn to_wide_null(s: &str) -> Vec<u16> {
-    let mut v: Vec<u16> = s.encode_utf16().collect();
-    v.push(0);
-    v
-}
-
 pub fn eval(_guard: &Guard<'_>, code: &str) -> Result<Value> {
-    let script = to_wide_null(code);
-    let url = to_wide_null("eval.js");
-
-    let mut out: sys::JsValueRef = std::ptr::null_mut();
     unsafe {
-        ok(sys::JsRunScript(
-            script.as_ptr(),
-            0 as sys::JsSourceContext,
+        let mut script_val: sys::JsValueRef = std::ptr::null_mut();
+        let mut url_val: sys::JsValueRef = std::ptr::null_mut();
+
+        ok(sys::JsCreateString(
+            code.as_ptr(),
+            code.len(),
+            &mut script_val,
+        ))?;
+
+        let url = "eval.js";
+        ok(sys::JsCreateString(
             url.as_ptr(),
+            url.len(),
+            &mut url_val,
+        ))?;
+
+        let mut out: sys::JsValueRef = std::ptr::null_mut();
+        ok(sys::JsRun(
+            script_val,
+            0 as sys::JsSourceContext,
+            url_val,
+            sys::JsParseScriptAttributes::None,
             &mut out,
         ))?;
+
+        Ok(Value { raw: out })
     }
-    Ok(Value { raw: out })
 }


### PR DESCRIPTION
# Changes

`build.rs` : build with Cmake `3d6692f` ~ `8e080ea`
`stript.rs` : Fix segfault caused by wchar_t size mismatch on Linux `056f257`

## why delete JsRunScript?

JsRunScript(*const u16) allow only Windows
JsRun(JsValueRef) is available cross-platform.

[chakracore wiki](https://github.com/chakra-core/ChakraCore/wiki/JsRunScript)

## check points

JsCreateExternalArrayBuffer can be direct access. but i think it's not about now(port).
[JsCreateString](https://github.com/chakra-core/ChakraCore/wiki/JsCreateString)


# Configuration

need clang, gcc, git, python(maybe)

# What's Next Up

msbuild for cmd/PS